### PR TITLE
CRON-8104 Update routes.php

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -3,5 +3,5 @@
 $loginRoute = Config::get('saml.routes.login', 'login');
 $logoutRoute = Config::get('saml.routes.logout', 'logout');
 
-Route::get($loginRoute, 'SamlController@login');
-Route::get($logoutRoute, 'SamlController@logout');
+Route::get($loginRoute, 'SamlController@login')->name('login');
+Route::get($logoutRoute, 'SamlController@logout')->name('logout');


### PR DESCRIPTION
laravel uses route names for shorthand to define which route goes to which controller action.
somewhere in laravel vendor backend logic it calls the route name login, since there is no route name for this controller action it doesn't find it.